### PR TITLE
feat: implement automatic test container cleanup using destructor pattern

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,12 +39,12 @@ jobs:
           sudo chmod 400 tests/tls/*.key
           sudo chown 70 tests/tls/server.key
 
-      - name: Test with latest PostgreSQL version (17)
+      - name: Test with latest PostgreSQL version (18)
         run: cargo test
 
-      - name: Test with minimal supported PostgreSQL version (13)
+      - name: Test with minimal supported PostgreSQL version (14)
         env:
-          PG_VERSION: "13"
+          PG_VERSION: "14"
         run: cargo test
 
       - name: Test with still used PostgreSQL version (11)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2137ce22f50d4c43ce098daf41c904cc700de1ce8bc2daf53ed4e702180a464"
+dependencies = [
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1817,7 @@ version = "0.3.6"
 dependencies = [
  "axum",
  "clap",
+ "dtor",
  "envsubst",
  "human-repr",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 
 [dev-dependencies]
+dtor = "1.0.3"
 insta = { version = "1.47.2", features = ["yaml"] }
 reqwest = { version = "0.13.3", default-features = false }
 rstest = "0.26.1"

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,10 +1,14 @@
+use dtor::dtor;
 use std::{
+    env,
     net::SocketAddr,
     path::Path,
     sync::atomic::{AtomicU16, Ordering},
+    thread,
 };
 use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
-use tokio::sync::OnceCell;
+use tokio::runtime::Runtime;
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use tracing::info;
 
 use crate::db::{PostgresConnectionString, PostgresSslMode};
@@ -18,6 +22,8 @@ pub const TEST_CLIENT_CERT: &str = "tests/tls/client.crt";
 pub const TEST_CLIENT_KEY: &str = "tests/tls/client.key";
 pub const TEST_SERVER_CERT: &str = "tests/tls/server.crt";
 pub const TEST_SERVER_KEY: &str = "tests/tls/server.key";
+
+const DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME: &str = "DISABLE_CONTAINER_DESTRUCTORS";
 
 pub fn next_addr() -> SocketAddr {
     static PORT: AtomicU16 = AtomicU16::new(9000);
@@ -33,13 +39,17 @@ pub async fn init_tracing() {
         .await;
 }
 
-static PSQL_CONTAINER: OnceCell<ContainerAsync<images::Postgres>> = OnceCell::const_new();
+static PSQL_CONTAINER: OnceCell<RwLock<Option<ContainerAsync<images::Postgres>>>> =
+    OnceCell::const_new();
 
 pub async fn init_psql_server() -> u16 {
     init_tracing().await;
 
-    let port = psql_server_container()
-        .await
+    let container_lock = psql_server_container().await;
+    let container = container_lock.read().await;
+    let port = container
+        .as_ref()
+        .unwrap()
         .get_host_port_ipv4(5432)
         .await
         .unwrap();
@@ -49,14 +59,18 @@ pub async fn init_psql_server() -> u16 {
 }
 
 pub async fn drop_psql_server() {
-    let container = psql_server_container().await;
-    container.stop().await.unwrap();
+    let container_lock = psql_server_container().await;
+    let mut container = container_lock.write().await;
+    if let Some(c) = container.take() {
+        c.stop().await.unwrap();
+        c.rm().await.unwrap();
+    }
 }
 
-async fn psql_server_container() -> &'static ContainerAsync<images::Postgres> {
+async fn psql_server_container() -> &'static RwLock<Option<ContainerAsync<images::Postgres>>> {
     PSQL_CONTAINER
         .get_or_init(async || {
-            images::Postgres::default()
+            let container = images::Postgres::default()
                 .with_db_name(TEST_DB_NAME)
                 .with_user(TEST_DB_USER)
                 .with_password(TEST_DB_PASSWORD)
@@ -69,7 +83,8 @@ async fn psql_server_container() -> &'static ContainerAsync<images::Postgres> {
                 ))
                 .start()
                 .await
-                .unwrap()
+                .unwrap();
+            RwLock::new(Some(container))
         })
         .await
 }
@@ -243,6 +258,30 @@ mod images {
                 vec![]
             }
         }
+    }
+}
+
+#[dtor(unsafe)]
+fn shutdown_test_containers() {
+    static LOCK: Mutex<()> = Mutex::const_new(());
+
+    if env::var(DISABLE_CONTAINER_DESTRUCTORS_ENV_NAME).is_err() {
+        let _ = thread::spawn(|| {
+            Runtime::new().unwrap().block_on(async {
+                let _guard = LOCK.lock().await;
+
+                if let Some(container_lock) = PSQL_CONTAINER.get() {
+                    let mut container = container_lock.write().await;
+                    if container.is_some() {
+                        let old = container.take().unwrap();
+                        let _ = old.stop().await;
+                        let _ = old.rm().await;
+                        *container = None;
+                    }
+                }
+            });
+        })
+        .join();
     }
 }
 


### PR DESCRIPTION
## Summary

Implements automatic cleanup of test containers after test execution using a destructor pattern, eliminating orphaned Docker containers left behind after integration tests.

## Changes

- **Add dtor crate**: Added `dtor 1.0.3` to dev-dependencies for process-exit callback functionality
- **Refactor container management**: Changed `PSQL_CONTAINER` from `OnceCell<ContainerAsync<>>` to `OnceCell<RwLock<Option<ContainerAsync<>>>>` for thread-safe lifecycle management
- **Implement destructor**: Added `#[dtor(unsafe)] fn shutdown_test_containers()` that automatically runs at process exit:
  - Stops the PostgreSQL container cleanly
  - Removes the container to free Docker resources
  - Can be disabled via `DISABLE_CONTAINER_DESTRUCTORS` environment variable (useful for debugging)
  - Uses mutex-protected cleanup to prevent concurrent attempts
- **Update helper functions**: Modified `init_psql_server()` and `drop_psql_server()` to work with the wrapped container via RwLock
- **Update CI**: Test with PostgreSQL versions 18 and 14 instead of 17 and 13

## Implementation Pattern

Based on the destructor pattern from [git-events-runner](https://github.com/alex-karpenko/git-events-runner), this ensures test containers are properly cleaned up even if test code doesn't explicitly call cleanup functions.

## Testing

All 33 tests pass successfully. The container cleanup is verified by the absence of orphaned containers after test suite completion.